### PR TITLE
くっつけた時次の弾き操作までの時間が長くなる不具合を改善した

### DIFF
--- a/ChewyFly_Prototype_Project/Assets/Prefabs/DonutsUnion.prefab
+++ b/ChewyFly_Prototype_Project/Assets/Prefabs/DonutsUnion.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  maxBounceTime: 0.5
+  maxBounceTime: 0.3
   maxBounceScaleSize: 1
   sphereDistance: 0.9
 --- !u!54 &-6562012546730319946

--- a/ChewyFly_Prototype_Project/Assets/Scripts/Player/FlicStrength.cs
+++ b/ChewyFly_Prototype_Project/Assets/Scripts/Player/FlicStrength.cs
@@ -122,12 +122,13 @@ public class FlicStrength : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
+        lastFlicTime += Time.fixedDeltaTime;
+
         if (playerController.ridingDonut != null && !playerController.ridingDonutUnion.isBouncing)    //ドーナツに乗っていてドーナツがバウンド中でない場合
         {
             var direction = input.isLeftStick();
             direction = playerController.playerCamera.transform.TransformDirection(direction);
 
-            lastFlicTime += Time.fixedDeltaTime;
 
             if (isJumpMode)
             {


### PR DESCRIPTION
密度変更のブランチが却下になったためこのコミットのみ別で用意
さらにBounceTimeを短くした